### PR TITLE
fix: update to ConfigParser due to Python 3 API change

### DIFF
--- a/bibtex2html/bibtex2html.py
+++ b/bibtex2html/bibtex2html.py
@@ -1592,7 +1592,7 @@ def main():
     params['verbose'] = _verbose
 
 
-    config = configparser.SafeConfigParser()
+    config = configparser.ConfigParser()
     if args['--conf']:
         param_str = 'params'
         config.read(_conffile)


### PR DESCRIPTION
Previous runs show: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2.
Simply update to the recommended ConfigParser to remove the above warning.

